### PR TITLE
URL encode the username before passing it into the URI

### DIFF
--- a/Source/YouCast/MainWindow.xaml.cs
+++ b/Source/YouCast/MainWindow.xaml.cs
@@ -94,6 +94,7 @@ namespace YouCast
 
         private string GenerateUrl(string userId, YouTubeEncoding encoding, int maxLength, bool isPopular)
         {
+            userId = WebUtility.UrlEncode(userId);
             var selectedItem = ComboBox.SelectedItem as ListBoxItem;
             if (Equals(selectedItem, UserNameItem))
             {


### PR DESCRIPTION
Hey, saw your PR on my project so I thought I'd reciprocate.

I added a `UrlEncode` on the user's ID before formatting it into the URI, to protect against cases like `"&&&&"` or names with spaces.