### PR TITLE
Update VideoLibrary to 1.3.2

### DIFF
--- a/Source/Service/Service.csproj
+++ b/Source/Service/Service.csproj
@@ -70,7 +70,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="libvideo, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VideoLibrary.1.3.1\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\libvideo.dll</HintPath>
+      <HintPath>..\packages\VideoLibrary.1.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\libvideo.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Source/Service/packages.config
+++ b/Source/Service/packages.config
@@ -13,6 +13,6 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="morelinq" version="2.0.0-alpha01" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="VideoLibrary" version="1.3.1" targetFramework="net45" />
+  <package id="VideoLibrary" version="1.3.2" targetFramework="net45" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Recently fixed a bug where encrypted videos would fail to download in [libvideo](https://github.com/jamesqo/libvideo/issues/25), so I thought I'd make a pull request here to update the package.