### PR TITLE
Change the UI to use Material Design

### DIFF
--- a/Source/YouCast/App.xaml
+++ b/Source/YouCast/App.xaml
@@ -4,35 +4,46 @@
              xmlns:properties="clr-namespace:YouCast.Properties"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-        <properties:Settings x:Key="Settings" />
-        <Style 
-            x:Key="LinkButton" 
-            TargetType="Button" 
-            BasedOn="{StaticResource ResourceKey={x:Type Button}}">
-            <Setter Property="Width" Value="Auto"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <ContentPresenter 
-                            Content="{TemplateBinding Content}" 
-                            ContentTemplate="{TemplateBinding  ContentTemplate}"
-                            VerticalAlignment="Center">
-                            <ContentPresenter.Resources>
-                                <Style TargetType="{x:Type TextBlock}">
-                                    <Setter Property="TextDecorations" Value="Underline" />
-                                </Style>
-                            </ContentPresenter.Resources>
-                        </ContentPresenter>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Setter Property="Foreground" Value="Blue" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="true">
-                    <Setter Property="Foreground" Value="Red" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+
+            </ResourceDictionary.MergedDictionaries>
+
+            <properties:Settings x:Key="Settings" />
+            <Style 
+                x:Key="LinkButton" 
+                TargetType="Button" 
+                BasedOn="{StaticResource ResourceKey={x:Type Button}}">
+                <Setter Property="Width" Value="Auto"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <ContentPresenter 
+                                Content="{TemplateBinding Content}" 
+                                ContentTemplate="{TemplateBinding  ContentTemplate}"
+                                VerticalAlignment="Center">
+                                <ContentPresenter.Resources>
+                                    <Style TargetType="{x:Type TextBlock}">
+                                        <Setter Property="TextDecorations" Value="Underline" />
+                                    </Style>
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Foreground" Value="Blue" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="true">
+                        <Setter Property="Foreground" Value="Red" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Source/YouCast/MainWindow.xaml
+++ b/Source/YouCast/MainWindow.xaml
@@ -5,13 +5,15 @@
         Loaded="Window_Loaded_1"
         Icon="rss.ico"
         StateChanged="Window_StateChanged_1"
-        FontFamily="tahoma"
         FontSize="13"
         Title="{x:Static youCast:GeneralInformation.ApplicationName}" 
         Height="295" 
         Width="463" 
         ResizeMode="CanMinimize" 
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        Background="{DynamicResource MaterialDesignPaper}"
+        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
     <TabControl>
         <TabItem Header="Podcast">
                 <StackPanel>

--- a/Source/YouCast/YouCast.csproj
+++ b/Source/YouCast/YouCast.csproj
@@ -13,10 +13,14 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -51,6 +55,14 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
+    <Reference Include="MaterialDesignColors, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.1.1.2\lib\net45\MaterialDesignColors.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=1.4.1.485, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.1.4.1.485\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>

--- a/Source/YouCast/packages.config
+++ b/Source/YouCast/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MaterialDesignColors" version="1.1.2" targetFramework="net45" />
+  <package id="MaterialDesignThemes" version="1.4.1.485" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />


### PR DESCRIPTION
I decided to go ahead and change the project to use [Material Design in XAML](https://github.com/ButchersBoy/MaterialDesignInXamlToolkit), following the [Getting Started](http://materialdesigninxaml.net/#getStarted) guide on the project's homepage. Here is how it looks with the new design:

![](http://i.imgur.com/vVaE3Ec.png)

If you'd like, [here's](http://i.imgur.com/vVaE3Ec.png) the link to the image. If you want to merge this PR, you can copy/paste it into your README.
