### PR TITLE
Updated GitHub pages "Download" link to point to the latest release

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <section class="page-header">
       <h1 class="project-name">YouCast</h1>
       <h2 class="project-tagline">Turn YouTube Channels into Subscribable Podcasts</h2>
-      <a href="https://github.com/i3arnon/YouCast/releases/download/2.2.0/YouCast.v2.2.zip" class="btn">Download</a>
+      <a href="https://github.com/i3arnon/YouCast/releases/download/2.20.0/YouCast.v2.20.zip" class="btn">Download</a>
       <a href="https://github.com/i3arnon/YouCast/releases" class="btn">Releases</a>
       <a href="https://github.com/i3arnon/YouCast" class="btn">View on GitHub</a>
     </section>


### PR DESCRIPTION
This previously pointed to the 2.2.0 release from 2016, which no longer functions due to changes in Youtube's API.
The GitHub pages site is indexed by search engines, so people may only ever visit http://youcast.i3arnon.com/, and not realize the "download" button links to a very old release.