### PR TITLE
Updated services to fix 404 errors #85

### DIFF
--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -49,12 +49,12 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.57.0.2756" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.60.0.2945" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="morelinq" Version="3.4.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="YoutubeExplode" Version="6.2.2" />
+    <PackageReference Include="YoutubeExplode" Version="6.2.13" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="obj\**" />


### PR DESCRIPTION
A simple update to the NuGet services in order to fix the 404 errors (see issue #85)

The attached file contains the compiled version of the code, so my fellow users don't have to compile it themselves. I'll remove it once a proper release is made.

Edit: Removed temp release file
